### PR TITLE
Adding Guest Access

### DIFF
--- a/mr-docs/remote-assist/cross-company-calling.md
+++ b/mr-docs/remote-assist/cross-company-calling.md
@@ -26,7 +26,10 @@ see [Manage external access (federation) in Microsoft Teams](https://docs.micros
 2.	To check to see if a contact in another domain has external access enabled in their company’s [!include[pn-microsoft-teams](../includes/pn-microsoft-teams.md)] admin center, try typing the contact's full email address in Teams Desktop. When external access is allowed between both domains, [!include[pn-teams](../includes/pn-teams.md)] shows the following message:
 
     ![Confirmation message](media/access-enabled-confirmation.PNG "Confirmation message")
+    
+Users in your organization can also use [guest access](https://docs.microsoft.com/en-us/microsoftteams/guest-access) to allow individual users from outside your organization to join your teams and channels in [!include[pn-microsoft-teams](../includes/pn-microsoft-teams.md)] and make or receive calls. Make sure to follow the steps in this [checklist](https://docs.microsoft.com/en-us/microsoftteams/guest-access) to set up the prerequisites and so [!include[pn-microsoft-teams](../includes/pn-microsoft-teams.md)] owners can add guest users to their teams.
  
 ### See also
 
 [Dynamics 365 Remote Assist user guide](https://docs.microsoft.com/dynamics365/mixed-reality/remote-assist/user-guide#make-and-receive-calls)
+[Guest Access in [!include[pn-microsoft-teams](../includes/pn-microsoft-teams.md)]](https://docs.microsoft.com/en-us/microsoftteams/guest-access)


### PR DESCRIPTION
Guest access is also a possibility to set up cross company calls. In fact it is mentioned as a prerequisite for cross company calls in the official Onboarding Training for Dynamics 365 Customer Service for Support Engineers [here](https://microsoft.sharepoint.com/teams/D365Readiness/Shared%20Documents/Forms/AllItems.aspx?id=%2Fteams%2FD365Readiness%2FShared%20Documents%2FDynamics%20365%2FCustomer%20Service%2F9%2E1%20Onboarding%20Training&p=true&originalPath=aHR0cHM6Ly9taWNyb3NvZnQuc2hhcmVwb2ludC5jb20vOmY6L3QvRDM2NVJlYWRpbmVzcy9FdEFHS2NCLVVxSktoLUpzS2lfaW4xWUJ3V2tUcFVwX0Nfc3dGei1jVkJqekx3P3J0aW1lPUFuM1lZVFBBMTBn)