### PR TITLE
Added RapidCompact to list of converter / optimizer tools

### DIFF
--- a/mr-docs/import-tool/optimize-models.md
+++ b/mr-docs/import-tool/optimize-models.md
@@ -19,6 +19,7 @@ The following table lists software tools that you can use to convert and/or opti
 |---------------------------------|----------------------------------------|--------------------|--------------------|-------------------|
 |[PiXYZ Software](https://aka.ms/Pixyz)|STEP, Catia, JT, OBJ, FBX, and more|glTF 2.0|Yes|Yes|
 |[Maxon Cinema 4D](https://aka.ms/MaxonCinema4D)|SOLIDWORKS, STEP, Catia, JT, and IGES|FBX, OBJ, GLB/glTF 2.0 (beta)|Yes|Yes|
+|[RapidCompact Software](http://rapidcompact.com/)|glTF, FBX, OBJ, STEP, JT, and more|glTF 2.0, OBJ, and more|Yes|Yes|
 |[Simplygon Studios](https://aka.ms/Simplygonsoftware)|FBX, OBJ|FBX|No|Yes|
 |[Unreal Datasmith](https://aka.ms/UnrealDatasmithsoftware)|STEP, Catia, JT, OBJ, FBX, and more|FBX, OBJ|Yes|No|
 |[Autodesk Inventor](https://aka.ms/AutodeskInventorSoftware)|STEP, Catia, JT, OBJ, FBX, and more|FBX, OBJ, STL|Yes|Yes|

--- a/mr-docs/import-tool/optimize-models.md
+++ b/mr-docs/import-tool/optimize-models.md
@@ -19,7 +19,7 @@ The following table lists software tools that you can use to convert and/or opti
 |---------------------------------|----------------------------------------|--------------------|--------------------|-------------------|
 |[PiXYZ Software](https://aka.ms/Pixyz)|STEP, Catia, JT, OBJ, FBX, and more|glTF 2.0|Yes|Yes|
 |[Maxon Cinema 4D](https://aka.ms/MaxonCinema4D)|SOLIDWORKS, STEP, Catia, JT, and IGES|FBX, OBJ, GLB/glTF 2.0 (beta)|Yes|Yes|
-|[RapidCompact Software](http://rapidcompact.com/)|glTF, FBX, OBJ, STEP, JT, and more|glTF 2.0, OBJ, and more|Yes|Yes|
+|[RapidCompact Software](https://rapidcompact.com/)|glTF, FBX, OBJ, STEP, JT, and more|glTF 2.0, OBJ, and more|Yes|Yes|
 |[Simplygon Studios](https://aka.ms/Simplygonsoftware)|FBX, OBJ|FBX|No|Yes|
 |[Unreal Datasmith](https://aka.ms/UnrealDatasmithsoftware)|STEP, Catia, JT, OBJ, FBX, and more|FBX, OBJ|Yes|No|
 |[Autodesk Inventor](https://aka.ms/AutodeskInventorSoftware)|STEP, Catia, JT, OBJ, FBX, and more|FBX, OBJ, STL|Yes|Yes|


### PR DESCRIPTION
Hi Dynamics 365 team,


thanks for your great work!


With this PR, I have added our RapidCompact software to the list of tools. Please let me know if it is fine like this.


BTW, off-topic: Your listing of "Performance targets" on the same page is highly interesting - I am co-chair of the 3D Commerce Asset Creation TSG at Khronos, and we are working on official [Asset Creation Guidelines](https://www.khronos.org/blog/3d-commerce-working-group-upcoming-real-time-asset-creation-guidelines-for-retail-and-e-commerce) for 3D pipelines in e-commerce. It would be highly interesting to see if we can link / align our recommendations for what we called "Publishing Targets" with the "Performance targets" mentioned here. Feel free to get in touch at any time, in case you're interested in this topic : )



